### PR TITLE
feat: add Laravel Sanctum for API authentication

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api;
 
+use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
-final class ApiUserController extends Controller
+final class UserController extends Controller
 {
     public function __construct()
     {

--- a/app/Http/Controllers/ApiUserController.php
+++ b/app/Http/Controllers/ApiUserController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ApiUserController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('abilities:read');
+    }
+
+    /**
+     * Retrieve the authenticated user.
+     *
+     * Get the authenticated user.
+     */
+    public function user(Request $request)
+    {
+        return new JsonResource($request->user());
+    }
+
+    /**
+     * Retrieve a user.
+     *
+     * Get a specific user object.
+     */
+    public function show(Request $request, User $user)
+    {
+        return new JsonResource($user);
+    }
+
+    /**
+     * List all users.
+     *
+     * Get all the users in the account.
+     */
+    public function index(Request $request)
+    {
+        $users = $request->user()->account->users();
+
+        return JsonResource::collection($users);
+    }
+}

--- a/app/Http/Controllers/ApiUserController.php
+++ b/app/Http/Controllers/ApiUserController.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class ApiUserController extends Controller
+final class ApiUserController extends Controller
 {
     public function __construct()
     {

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+abstract class Controller extends BaseController
 {
-    //
+    use AuthorizesRequests;
+    use DispatchesJobs;
+    use ValidatesRequests;
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,9 +12,10 @@ use Laravel\Sanctum\HasApiTokens;
 
 final class User extends Authenticatable
 {
+    use HasApiTokens;
+
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory;
-    use HasApiTokens;
     use Notifiable;
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,6 +16,7 @@ final class User extends Authenticatable
 
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory;
+
     use Notifiable;
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,11 +8,14 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 final class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory;
+    use HasApiTokens;
+    use Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 final class AppServiceProvider extends ServiceProvider
@@ -36,5 +38,7 @@ final class AppServiceProvider extends ServiceProvider
 
         // Throws an exception if you try to read an attribute that isn’t actually on the model
         Model::preventAccessingMissingAttributes();
+
+        RateLimiter::for('api', fn (Request $request) => Limit::perMinute(60)->by(optional($request->user())->id ?: $request->ip()));
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,21 +5,32 @@ declare(strict_types=1);
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Laravel\Sanctum\Http\Middleware\CheckAbilities;
+use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 use Symfony\Component\HttpFoundation\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->throttleApi();
         $middleware->trustProxies(headers: Request::HEADER_X_FORWARDED_FOR |
             Request::HEADER_X_FORWARDED_HOST |
             Request::HEADER_X_FORWARDED_PORT |
             Request::HEADER_X_FORWARDED_PROTO |
             Request::HEADER_X_FORWARDED_AWS_ELB
         );
+        $middleware->alias([
+            'abilities' => CheckAbilities::class,
+            'ability' => CheckForAnyAbility::class,
+        ]);
+        $middleware->api(prepend: [
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -29,7 +29,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'ability' => CheckForAnyAbility::class,
         ]);
         $middleware->api(prepend: [
-            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "driftingly/rector-laravel": "^2.0",
         "joshbrw/laravel-module-installer": "^2.0",
         "laravel/framework": "^12.0",
+        "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10.1",
         "nwidart/laravel-modules": "^12.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c19ee5c7354c246f60fd3bef58cc6aa",
+    "content-hash": "0b6b4d6b566e5a5be1a0cd27fb930463",
     "packages": [
         {
             "name": "brick/math",
@@ -1408,6 +1408,70 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.7"
             },
             "time": "2025-09-19T13:47:56+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "fd6df4f79f48a72992e8d29a9c0ee25422a0d677"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/fd6df4f79f48a72992e8d29a9c0ee25422a0d677",
+                "reference": "fd6df4f79f48a72992e8d29a9c0ee25422a0d677",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0",
+                "illuminate/contracts": "^11.0|^12.0",
+                "illuminate/database": "^11.0|^12.0",
+                "illuminate/support": "^11.0|^12.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.0|^10.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2025-07-09T19:45:24+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Sanctum\Sanctum;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stateful Domains
+    |--------------------------------------------------------------------------
+    |
+    | Requests from the following domains / hosts will receive stateful API
+    | authentication cookies. Typically, these should include your local
+    | and production domains which access your API via a frontend SPA.
+    |
+    */
+
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        Sanctum::currentApplicationUrlWithPort(),
+        // Sanctum::currentRequestHost(),
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | This array contains the authentication guards that will be checked when
+    | Sanctum is trying to authenticate a request. If none of these guards
+    | are able to authenticate the request, Sanctum will use the bearer
+    | token that's present on an incoming request for authentication.
+    |
+    */
+
+    'guard' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until an issued token will be
+    | considered expired. This will override any values set in the token's
+    | "expires_at" attribute, but first-party sessions are not affected.
+    |
+    */
+
+    'expiration' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
+    |
+    | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
+    |
+    */
+
+    'token_prefix' => env('SANCTUM_TOKEN_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Middleware
+    |--------------------------------------------------------------------------
+    |
+    | When authenticating your first-party SPA with Sanctum you may need to
+    | customize some of the middleware Sanctum uses while processing the
+    | request. You may change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => [
+        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
+        'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
+        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+    ],
+
+];

--- a/database/migrations/2025_09_29_165703_create_personal_access_tokens_table.php
+++ b/database/migrations/2025_09_29_165703_create_personal_access_tokens_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,7 +23,6 @@
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use App\Http\Controllers\ApiUserController;
+use App\Http\Controllers\Api\UserController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['auth:sanctum', 'throttle:60,1'])->group(function () {
-    Route::get('user', [ApiUserController::class, 'user']);
-    Route::apiResource('users', ApiUserController::class)->only(['index', 'show']);
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('user', [UserController::class, 'user']);
+    Route::apiResource('users', UserController::class)->only(['index', 'show']);
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\ApiUserController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['auth:sanctum', 'throttle:60,1'])->group(function () {
+    Route::get('user', [ApiUserController::class, 'user']);
+    Route::apiResource('users', ApiUserController::class)->only(['index', 'show']);
+});

--- a/tests/.env.ci.sqlite
+++ b/tests/.env.ci.sqlite
@@ -6,7 +6,7 @@ APP_DEBUG=true
 APP_URL=https://monica.test
 
 DB_CONNECTION=sqlite
-DB_DATABASE=database/database.sqlite
+DB_DATABASE=:memory:
 
 BROADCAST_DRIVER=log
 

--- a/tests/Feature/ApiTokenPermissionsTest.php
+++ b/tests/Feature/ApiTokenPermissionsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Support\Str;
+
+test('api token permissions can be updated', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $user->tokens()->create([
+        'name' => 'Test Token',
+        'token' => Str::random(40),
+        'abilities' => ['delete', 'read'],
+    ]);
+
+    expect($user->fresh()->tokens->first())
+        ->can('delete')->toBeTrue()
+        ->can('create')->toBeFalse()
+        ->can('missing-permission')->toBeFalse();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 */
 
 pest()->extend(Tests\TestCase::class)
- // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature');
 
 /*

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 
 pest()->extend(Tests\TestCase::class)
     ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->in('Feature');
+    ->in('Feature', 'Unit');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/Api/UserControllerTest.php
+++ b/tests/Unit/Api/UserControllerTest.php
@@ -24,7 +24,7 @@ test('api user get', function () {
         ['read']
     );
 
-    $response = $this->get('/api/users/' . $user->id)
+    $response = $this->get('/api/users/'.$user->id)
         ->assertOk();
 
     expect($response->json('data.id'))

--- a/tests/Unit/Api/UserControllerTest.php
+++ b/tests/Unit/Api/UserControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+test('api current user get', function () {
+    Sanctum::actingAs(
+        $user = User::factory()->create(),
+        ['read']
+    );
+
+    $response = $this->get('/api/user')
+        ->assertOk();
+
+    expect($response->json('data.id'))
+        ->toBe($user->id);
+});
+
+test('api user get', function () {
+    Sanctum::actingAs(
+        $user = User::factory()->create(),
+        ['read']
+    );
+
+    $response = $this->get('/api/users/' . $user->id)
+        ->assertOk();
+
+    expect($response->json('data.id'))
+        ->toBe($user->id);
+});

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,7 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-test('that true is true', function () {
-    expect(true)->toBeTrue();
-});


### PR DESCRIPTION
Integrate Laravel Sanctum to provide a lightweight authentication system for the API, including user management and token handling. Implement necessary routes, middleware, and migrations for personal access tokens.