### PR TITLE
chore: remove alpine ajax and turbo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,11 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@hotwired/turbo": "^8.0.13",
-        "@imacrayon/alpine-ajax": "^0.12.4",
         "@tailwindcss/vite": "^4.0.0",
         "alpinejs": "^3.15.0",
         "axios": "^1.11.0",
         "concurrently": "^9.0.1",
         "husky": "^9.1.7",
-        "instant.page": "^5.2.0",
         "laravel-vite-plugin": "^2.0.0",
         "lint-staged": "^16.2.3",
         "tailwindcss": "^4.0.0",
@@ -479,23 +476,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@hotwired/turbo": {
-      "version": "8.0.18",
-      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-8.0.18.tgz",
-      "integrity": "sha512-dG0N7khQsP8sujclodQE3DYkI4Lq7uKA04fhT0DCC/DwMgn4T4WM3aji6EC6+iCfABQeJncY0SraXqVeOq0vvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@imacrayon/alpine-ajax": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@imacrayon/alpine-ajax/-/alpine-ajax-0.12.4.tgz",
-      "integrity": "sha512-L8tJMCDddcE77XIVrTnOy21jscsbnJl0aBU6Vyu0v7WH5Esg+9N7Itr+ciNSZ44MUV2RskQLuoSVqrcO6Y0U8w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
@@ -1853,13 +1833,6 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
-    },
-    "node_modules/instant.page": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/instant.page/-/instant.page-5.2.0.tgz",
-      "integrity": "sha512-DUSwWyoHFOQnmEwJtg9vzDx8Ef8uNNvTxTmHjd0vN9/XEIb5EQkm/itpZMypoH3dJLJvtkrD97WOCKuMqDdMHQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,14 +7,11 @@
     "dev": "vite"
   },
   "devDependencies": {
-    "@hotwired/turbo": "^8.0.13",
-    "@imacrayon/alpine-ajax": "^0.12.4",
     "@tailwindcss/vite": "^4.0.0",
     "alpinejs": "^3.15.0",
     "axios": "^1.11.0",
     "concurrently": "^9.0.1",
     "husky": "^9.1.7",
-    "instant.page": "^5.2.0",
     "laravel-vite-plugin": "^2.0.0",
     "lint-staged": "^16.2.3",
     "tailwindcss": "^4.0.0",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,17 +1,6 @@
 import "./bootstrap";
 
-import "instant.page";
-
-// --- Turbo Drive ---
-// import * as Turbo from "@hotwired/turbo";
-// window.Turbo = Turbo;
-// Turbo.session.drive = true; // explicit (enabled by default)
-
-// --- Alpine ---
 import { Livewire, Alpine } from '../../vendor/livewire/livewire/dist/livewire.esm';
-import ajax from "@imacrayon/alpine-ajax";
-
-Alpine.plugin(ajax);
 Livewire.start();
 
 // Re-initialize Alpine after every Turbo-driven navigation

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,4 @@
 import "./bootstrap";
 
-import { Livewire, Alpine } from '../../vendor/livewire/livewire/dist/livewire.esm';
+import { Livewire } from '../../vendor/livewire/livewire/dist/livewire.esm';
 Livewire.start();

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -2,8 +2,3 @@ import "./bootstrap";
 
 import { Livewire, Alpine } from '../../vendor/livewire/livewire/dist/livewire.esm';
 Livewire.start();
-
-// Re-initialize Alpine after every Turbo-driven navigation
-// addEventListener("turbo:load", () => {
-//   if (window.Alpine?.initTree) Alpine.initTree(document.body);
-// });

--- a/resources/views/components/layouts/auth/split.blade.php
+++ b/resources/views/components/layouts/auth/split.blade.php
@@ -39,5 +39,6 @@
             </div>
         </div>
         @fluxScripts
+        @livewireScriptConfig
     </body>
 </html>

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -12,5 +12,6 @@
 <link rel="preconnect" href="https://fonts.bunny.net">
 <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
+@livewireStyles
 @vite(['resources/css/app.css', 'resources/js/app.js'])
 @fluxAppearance


### PR DESCRIPTION
We do not need Alpine Ajax, Turbo and Instant Page anymore, since we have Livewire now.
I've also added `@livewireStyles` and `@livewireScriptConfig` to fix JS errors in console.